### PR TITLE
refactor(OptimizedImage): remove try/catch redundancy

### DIFF
--- a/src/components/global/OptimizedImage.tsx
+++ b/src/components/global/OptimizedImage.tsx
@@ -14,16 +14,12 @@ function slugify(input: string) {
 function deriveSlugFromSrc(src: string) {
   if (!src) return '';
   // If the caller provides a public path like /images/foo.jpg, extract base
-  try {
-    const url = new URL(src, 'http://example.com');
-    const pathname = url.pathname;
-    const name = pathname.split('/').pop() || pathname;
-    return slugify(name.replace(/\.[^/.]+$/, ''));
-  } catch {
-    // fallback for plain filenames
-    const name = src.split('/').pop() || src;
-    return slugify(name.replace(/\.[^/.]+$/, ''));
-  }
+  const url = src.startsWith('http')
+    ? new URL(src)
+    : new URL(src, 'http://example.com');
+  const pathname = url.pathname;
+  const name = pathname.split('/').pop() || pathname;
+  return slugify(name.replace(/\.[^/.]+$/, ''));
 }
 
 interface SimpleImageProps {


### PR DESCRIPTION
Replace try/catch pattern in deriveSlugFromSrc with a single code path using src.startsWith('http') to determine whether to construct new URL with or without a base URL. Both paths now follow identical extraction logic, eliminating duplicate code while maintaining identical output for absolute and relative src values.

Closes #12