### PR TITLE
refactor(app): extract getScreenSize to utils and remove eslint suppr…

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,7 +5,7 @@ import { PageErrorBoundary } from '@/components/global/ErrorBoundaryWrappers';
 import Projects from '@/app/routes/Projects';
 
 import { MediaQueryContext } from '@/utils/context';
-import { useScreenSize } from '@/utils/site';
+import { useScreenSize, getScreenSize } from '@/utils/site';
 
 import type { MediaSizes } from '@/utils/site';
 import { trackPageView } from '@/utils/analytics';
@@ -16,25 +16,10 @@ function App() {
 
     // a media query used to determine hexlayouts and hexWidths.
   const screenSize = useScreenSize();
-  function getScreenSize(): MediaSizes {
-    const size: MediaSizes =
-      screenSize.width > 1919
-        ? "x-large"
-        : screenSize.width > 1439
-        ? "large"
-        : screenSize.width > 1023
-        ? "desktop"
-        : screenSize.width > 639
-        ? "tablet"
-        : "mobile";
-    return size;
-  }
-
-  const [mediaSize, setMediaSize] = useState<MediaSizes>(getScreenSize());
+  const [mediaSize, setMediaSize] = useState<MediaSizes>(getScreenSize(screenSize.width));
 
   useEffect(() => {
-    setMediaSize(getScreenSize())
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    setMediaSize(getScreenSize(screenSize.width))
   }, [screenSize.width]);
 
   return (

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -81,3 +81,17 @@ export function createAccessibleDescription(text: string, maxLength: number = 15
     ? truncated.substring(0, lastSpace)
     : truncated;
 }
+
+export function getScreenSize(width: number): MediaSizes {
+  const size: MediaSizes =
+    width > 1919
+      ? "x-large"
+      : width > 1439
+      ? "large"
+      : width > 1023
+      ? "desktop"
+      : width > 639
+      ? "tablet"
+      : "mobile";
+  return size;
+}


### PR DESCRIPTION
…ession

Moved the getScreenSize function out of the App component render cycle into src/utils/site.ts as a pure utility function. This eliminates the need for the eslint-disable-next-line react-hooks/exhaustive-deps comment since the function is now stable across renders. Runtime behavior unchanged.

Closes #13