### PR TITLE
refactor(useProjectFilters): remove ref+effect callback sync pattern

### DIFF
--- a/src/features/projects/hooks/useProjectFilters.ts
+++ b/src/features/projects/hooks/useProjectFilters.ts
@@ -1,18 +1,10 @@
-import { useState, useCallback, useEffect, useRef, startTransition, useMemo } from 'react'
+import { useState, useCallback, useEffect, startTransition, useMemo } from 'react'
 import { getAllProjectsSorted, filterProjects } from '@/utils/projects'
 import type { ProjectType } from '@/data/projects/projects'
 
 export function useProjectFilters(initialRoleIds: string[] = [], initialTechIds: string[] = [], onFiltersChange?: (roleIds: string[], techIds: string[]) => void) {
   const [selectedRoleIds, setSelectedRoleIds] = useState<string[]>(initialRoleIds)
   const [selectedTechIds, setSelectedTechIds] = useState<string[]>(initialTechIds)
-  
-  // Use ref to avoid adding callback to useEffect dependencies
-  const onFiltersChangeRef = useRef(onFiltersChange)
-  
-  // Keep ref updated with latest callback
-  useEffect(() => {
-    onFiltersChangeRef.current = onFiltersChange
-  }, [onFiltersChange])
 
   const toggleRoleFilter = useCallback((filterId: string) => {
     setSelectedRoleIds(prev => {
@@ -28,16 +20,16 @@ export function useProjectFilters(initialRoleIds: string[] = [], initialTechIds:
 
   // Sync URL / parent after local state stabilizes
   useEffect(() => {
-    if (!onFiltersChangeRef.current) return
+    if (!onFiltersChange) return
 
     if (typeof startTransition === 'function') {
       startTransition(() => {
-        onFiltersChangeRef.current!(selectedRoleIds, selectedTechIds)
+        onFiltersChange(selectedRoleIds, selectedTechIds)
       })
     } else {
-      onFiltersChangeRef.current(selectedRoleIds, selectedTechIds)
+      onFiltersChange(selectedRoleIds, selectedTechIds)
     }
-  }, [selectedRoleIds, selectedTechIds])
+  }, [selectedRoleIds, selectedTechIds, onFiltersChange])
 
   // Derived project list for consumers (ProjectIndex / ProjectGrid expect this)
   const allProjects = useMemo<ProjectType[]>(() => getAllProjectsSorted(), [])


### PR DESCRIPTION
Previously, the hook used useRef + a syncing useEffect to avoid listing the onFiltersChange callback in the main effect's dependencies. This was defensive over-engineering.

Simplified by:
- Removing useRef and the ref update effect
- Using onFiltersChange directly in the main effect
- Adding onFiltersChange to the dependency array

The behavior remains unchanged at runtime; filter sync still uses startTransition to defer parent updates.

Closes #14