### PR TITLE
fix(App): restore type safety in RouterEventListener

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -69,11 +69,10 @@ function RouterEventListener() {
   }, [location]);
 
   useEffect(() => {
-    const handler = (evt: Event) => {
+    const handler = (evt: CustomEvent<{ targetUrl: string }>) => {
       try {
-        const detail = (evt as CustomEvent)?.detail || (evt as any).detail;
-        if (detail && detail.targetUrl) {
-          navigate(detail.targetUrl);
+        if (evt.detail && evt.detail.targetUrl) {
+          navigate(evt.detail.targetUrl);
         }
       } catch (e) {
         console.error('RouterEventListener: Navigation failed', e);


### PR DESCRIPTION
Replaced unsafe (evt as any) type cast with proper CustomEvent<{ targetUrl: string }>
typing. Simplified detail access to directly use evt.detail.

Closes #15