### PR TITLE
chore(tsconfig): enable strict and fix noEmit

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -13,7 +13,7 @@
     "allowImportingTsExtensions": false,
     "verbatimModuleSyntax": false,
     "moduleDetection": "force",
-    "noEmit": false,
+    "noEmit": true,
     "jsx": "react-jsx",
 
     /* Linting */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,8 @@
   "compilerOptions": {
   "baseUrl": ".",
   "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
     "types": ["vite/client"],
     "paths": {
       "@/*": ["./src/*", "./src"]

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -11,7 +11,7 @@
     "allowImportingTsExtensions": false,
     "verbatimModuleSyntax": false,
     "moduleDetection": "force",
-    "noEmit": false,
+    "noEmit": true,
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
Added strict: true and skipLibCheck: true to base tsconfig.json to enforce strict type-checking across the project. Changed oEmit
from false to true in both tsconfig.app.json and tsconfig.node.json since Vite is responsible for output generation, not TypeScript.

Closes #16