### PR TITLE
cleanup(code-quality): remove duplicates, name magic numbers, guard c…

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,7 +7,7 @@ import Projects from '@/app/routes/Projects';
 import { MediaQueryContext } from '@/utils/context';
 import { useScreenSize, getScreenSize } from '@/utils/site';
 
-import type { MediaSizes } from '@/utils/site';
+import type { MediaSizes } from '@/types/layout';
 import { trackPageView } from '@/utils/analytics';
 
 import './styles/index.css'
@@ -75,7 +75,9 @@ function RouterEventListener() {
           navigate(evt.detail.targetUrl);
         }
       } catch (e) {
-        console.error('RouterEventListener: Navigation failed', e);
+        if (import.meta.env.DEV) {
+          console.error('RouterEventListener: Navigation failed', e);
+        }
       }
     };
 

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -14,7 +14,12 @@ initPerformanceMonitoring()
 // Initialize analytics immediately (before render)
 initialize();
 
-createRoot(document.getElementById('root')!).render(
+const rootElement = document.getElementById('root');
+if (!rootElement) {
+  throw new Error('Root element with id="root" not found in DOM');
+}
+
+createRoot(rootElement).render(
   <StrictMode>
     <AppErrorBoundary>
       <App />

--- a/src/app/polyfills.ts
+++ b/src/app/polyfills.ts
@@ -23,8 +23,10 @@ try {
   smoothscrollPolyfill();
 } catch (e) {
   // Swallow; we don't want polyfill initialization to break app startup
-  // eslint-disable-next-line no-console
-  console.debug('smoothscroll polyfill failed to initialize', e);
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.debug('smoothscroll polyfill failed to initialize', e);
+  }
 }
 
 // NOTE: Do not import fetch or ResizeObserver polyfills here per request.

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -1,8 +1,12 @@
 import { useState, useEffect } from 'react';
 
-// Layout types
-export const mediaSizes = ["mobile", "tablet", "desktop", "large", "x-large"] as const;
-export type MediaSizes = typeof mediaSizes[number];
+import type { MediaSizes } from '@/types/layout';
+
+// Breakpoint constants for responsive design
+const BREAKPOINT_LARGE_DESKTOP = 1920;
+const BREAKPOINT_DESKTOP = 1440;
+const BREAKPOINT_TABLET = 1024;
+const BREAKPOINT_MOBILE = 640;
 
 export const useScreenSize = () => {
   const [screenSize, setScreenSize] = useState({
@@ -84,13 +88,13 @@ export function createAccessibleDescription(text: string, maxLength: number = 15
 
 export function getScreenSize(width: number): MediaSizes {
   const size: MediaSizes =
-    width > 1919
+    width >= BREAKPOINT_LARGE_DESKTOP
       ? "x-large"
-      : width > 1439
+      : width >= BREAKPOINT_DESKTOP
       ? "large"
-      : width > 1023
+      : width >= BREAKPOINT_TABLET
       ? "desktop"
-      : width > 639
+      : width >= BREAKPOINT_MOBILE
       ? "tablet"
       : "mobile";
   return size;


### PR DESCRIPTION
…onsole

• Remove duplicate mediaSizes definition from site.ts; use layout.ts import • Extract breakpoint magic numbers to named constants
  (BREAKPOINT_LARGE_DESKTOP=1920, BREAKPOINT_DESKTOP=1440,
   BREAKPOINT_TABLET=1024, BREAKPOINT_MOBILE=640)
• Guard console.error in App.tsx with import.meta.env.DEV • Guard console.debug in polyfills.ts with import.meta.env.DEV • Replace unsafe non-null assertion (!) on root element in Main.tsx
  with explicit null check that throws descriptive error
• Keep all three image helper functions (no consolidation needed)

Closes #17