### PR TITLE
refactor(hex): remove unjustified memoization

### DIFF
--- a/src/features/hexes/Hex.tsx
+++ b/src/features/hexes/Hex.tsx
@@ -54,7 +54,7 @@ export type HexProps = {
     : ''
 
   // Stable className so parent renders don't re-create string
-  const classes = useMemo(() => `hex ${hexClass} ${contentClass}`.trim(), [hexClass, contentClass])
+  const classes = `hex ${hexClass} ${contentClass}`.trim()
  
    // Stable keyboard handler
    const handleKeyDown = useCallback((event: React.KeyboardEvent) => {
@@ -116,19 +116,19 @@ export type HexProps = {
    // eslint-disable-next-line react-hooks/exhaustive-deps
    }, [contentType, content, contactId, hexWidth])
  
-  // Final memoized content
-  const hexContent = useMemo(() => (
+  // Content node
+  const hexContent = (
     <>
       {contentNode}
     </>
-  ), [contentNode])
+  )
  
    // Common props for all element types (stable identity)
   // Inline CSS vars for layout (moved from per-hex <style> into CSS variables)
-  const inlineVars: React.CSSProperties = useMemo(() => ({
+  const inlineVars: React.CSSProperties = {
     ['--hex-width' as any]: `${hexWidth}px`,
     ['--hex-margin' as any]: `${hexMargin}px`,
-  }), [hexWidth, hexMargin])
+  }
 
   const commonProps = useMemo(() => ({
     className: classes,

--- a/src/features/hexes/HexGridLayout.tsx
+++ b/src/features/hexes/HexGridLayout.tsx
@@ -41,12 +41,12 @@ const mediaQuery = useContext(MediaQueryContext);
     return null;
   }
 
-  const hexGridProps = useMemo(() => ({
+  const hexGridProps = {
     grid,
     shiftedUp: layout?.shiftedUp,
     hexWidth: layout?.hexWidth ? layout?.hexWidth : hexWidth,
     hexMargin: typeof layout?.hexMargin !== 'undefined' ? layout?.hexMargin : 3,
-  }), [grid, layout, hexWidth]);
+  };
 
   // chooses which hex grid to display based on screen size
   return (


### PR DESCRIPTION
Remove useMemo wrapping trivial string .trim() operation on classes. Remove double-memoization of hexContent (wrapped already-memoized contentNode). Remove useMemo from inlineVars plain object literal. Remove useMemo from hexGridProps passed to HexGrid component. Retain useMemo for contentNode computation and useCallback for keyboard event handler, which are justified optimizations.

Closes #18