### PR TITLE
docs(hex): add documentation to HexGridLayout and HexRow

### DIFF
--- a/src/features/hexes/HexGridLayout.tsx
+++ b/src/features/hexes/HexGridLayout.tsx
@@ -1,3 +1,19 @@
+/**
+ * HexGridLayout.tsx
+ *
+ * Responsive hex grid layout component that selects and renders the
+ * appropriate grid configuration based on the current media query.
+ *
+ * The layout model works as follows:
+ * 1. Resolve the layout object from the layouts map using the current mediaQuery
+ * 2. Use the layout's grid identifier to look up grid data (rows and hex positions)
+ * 3. Combine layout config (shiftedUp, hexWidth, hexMargin) with grid data
+ * 4. Pass everything to HexGrid for rendering
+ *
+ * This decouples grid structure (rows, hex positions) from visual styling
+ * (size, margin, shift), allowing multiple layouts to share the same grid data.
+ */
+
 import { logger } from '@/utils/logger';
 
 import { useContext, useMemo, memo } from "react";
@@ -25,10 +41,12 @@ const mediaQuery = useContext(MediaQueryContext);
 
   hexWidth = hexWidth ? hexWidth : 0;
 
+  // Resolve the appropriate layout config for the current screen size
   const layout = useMemo(() =>
     layouts[mediaQuery] ? layouts[mediaQuery] : undefined,
     [layouts, mediaQuery]
   );
+  // Look up the grid data (rows and hex coordinate positions) using the layout's grid identifier
   const grid = useMemo(() =>
     layout && gridData[layout?.grid] ? gridData[layout?.grid] : undefined,
     [layout]
@@ -41,6 +59,7 @@ const mediaQuery = useContext(MediaQueryContext);
     return null;
   }
 
+  // Combine grid structure with layout-specific visual config (hex size, margin, vertical shift)
   const hexGridProps = {
     grid,
     shiftedUp: layout?.shiftedUp,

--- a/src/features/hexes/HexRow.tsx
+++ b/src/features/hexes/HexRow.tsx
@@ -1,3 +1,21 @@
+/**
+ * HexRow.tsx
+ *
+ * Renders a row of hexagons with two rendering modes:
+ *
+ * Mode 1 (Preferred): Pass precomputed hexItems array
+ *   Each item is a partial Hex component props object, spread directly into <Hex />.
+ *   Sizing (hexWidth, hexMargin) can be passed as props or derived from the first item.
+ *
+ * Mode 2 (Fallback): Pass a row identifier
+ *   Looks up row definition in rowData, constructs hex items from hexData.
+ *   Handles hex repetition via the repeat config in rowData.
+ *   Bridges legacy prop names (hexLink, noTabIndex) to new Hex component.
+ *
+ * Both modes set CSS variables (--hex-width, --hex-margin) to enable
+ * CSS-based hex layout calculations.
+ */
+
 import { logger } from '@/utils/logger';
 
 import { useMemo } from 'react'
@@ -24,13 +42,14 @@ function HexRow({
   hexMargin,
   hexItems,
 }: HexRowProps) {
-  // If precomputed hex items are provided, render them directly (preferred path)
+  // Mode 1: If precomputed hex items are provided, render them directly (preferred path)
   if (Array.isArray(hexItems) && hexItems.length > 0) {
-    // Derive row-level CSS vars from explicit props or from the first item's sizing
+    // Derive row-level CSS variables from explicit props or from the first item's sizing
     const first = hexItems[0] || {}
     const derivedHexWidth = typeof hexWidth !== 'undefined' && hexWidth !== null ? hexWidth : (typeof first.hexWidth === 'number' ? first.hexWidth : 122)
     const derivedHexMargin = typeof hexMargin !== 'undefined' && hexMargin !== null ? hexMargin : (typeof first.hexMargin === 'number' ? first.hexMargin : 3)
 
+    // Set CSS custom properties so CSS-based layout calculations can use these values
     const rowVars: React.CSSProperties = {
       ['--hex-width' as any]: `${derivedHexWidth}px`,
       ['--hex-margin' as any]: `${derivedHexMargin}px`,
@@ -45,7 +64,7 @@ function HexRow({
     )
   }
 
-  // Backwards-compatible fallback: construct items from rowData/hexData
+  // Mode 2: Backwards-compatible fallback — construct items from rowData/hexData
   if (!row) {
     if (import.meta.env.DEV) {
       logger.warn(`HexRow: Missing row data. Expected row identifier but received: ${row}`);
@@ -61,6 +80,7 @@ function HexRow({
     hexMargin = 3;
   }
 
+  // Set CSS custom properties for hex sizing (used by CSS layout logic)
   const inlineVars: React.CSSProperties = useMemo(() => ({
     ['--hex-width' as any]: `${hexWidth}px`,
     ['--hex-margin' as any]: `${hexMargin}px`,
@@ -76,6 +96,7 @@ function HexRow({
           const hexId = hexObj.id
           // Safely resolve hex definition from hexData (avoid spreading undefined)
           const hexDef = hexData[hexId];
+          // Fall back to a minimal definition using hexId if not found in hexData
           let props = hexDef && hexDef.id ? { ...hexDef } : { id: hexId, hexClass: hexId };
             
           props = {
@@ -84,6 +105,7 @@ function HexRow({
             hexMargin: typeof hexMargin !== 'undefined' ? hexMargin : undefined,
           };
           
+          // Handle hex repetition: rowData can specify a repeat count for a single hex definition
           let maxHexes = hexObj.repeat || 1;
 
           let repeatPlaceholderArray = []
@@ -92,7 +114,7 @@ function HexRow({
           }
 
           return repeatPlaceholderArray.map((idx)=>{
-            // Map old prop names to new unified prop structure and cast to Partial<HexProps>
+            // Bridge legacy prop names (hexLink, noTabIndex) to new Hex component props
             const base = props as Partial<HexProps>
             const unifiedProps: Partial<HexProps> = {
               ...base,
@@ -101,7 +123,7 @@ function HexRow({
               tabIndex: base.noTabIndex ? -1 : base.tabIndex,
             }
 
-            // strip legacy keys if they exist (type, hexLink, noTabIndex)
+            // Remove legacy keys to avoid passing unsupported props to Hex component
             const { type: _t, onClick: _oc, hexLink: _hl, noTabIndex: _nt, ...cleanProps } = unifiedProps
             const stableKey = `${hexObj.id}-repeat-${idx}`;
             return (<Hex key={stableKey} {...(cleanProps as Partial<HexProps>)} />)


### PR DESCRIPTION
Inline comments added to HexGridLayout.tsx explaining the responsive layout resolution model and grid data lookup.

Inline comments added to HexRow.tsx explaining dual-mode rendering (precomputed hexItems vs row identifier fallback) and legacy prop name bridging.

Closes #19